### PR TITLE
Adding in ability to remove regular reply options at site level.

### DIFF
--- a/index.php
+++ b/index.php
@@ -51,6 +51,7 @@ if ($mform->is_cancelled()) {
     }
     set_config('defaultcourserole' , $data->defaultcourserole, 'local_anonymousposting');
     set_config('defaultactivityrole' , $data->defaultactivityrole, 'local_anonymousposting');
+    set_config('anonymousonly' , $data->anonymousonly, 'local_anonymousposting');
 }
 
 

--- a/index_form.php
+++ b/index_form.php
@@ -47,6 +47,10 @@ class local_anonymousposting_form extends moodleform {
         $mform->addElement('select', 'defaultactivityrole', get_string('defaultactivityrole', 'local_anonymousposting'), $assignableroles);
         $mform->setDefault('defaultactivityrole', '5');
 
+        $mform->addElement('checkbox', 'anonymousonly', get_string('anonymousonly', 'local_anonymousposting'),
+                get_string('anonymousonlydesc', 'local_anonymousposting'));
+        $mform->setDefault('anonymousonly', 0);
+
         $this->add_action_buttons();
     }
 

--- a/lang/en/local_anonymousposting.php
+++ b/lang/en/local_anonymousposting.php
@@ -45,5 +45,7 @@ $string['userfirstname'] = 'Anonymous';
 $string['userlastname'] = 'User';
 $string['youcannouseloginas'] = 'You can\'t use this function when you are login as other user';
 $string['relogin'] = 'Log in with my actual user';
+$string['anonymousonly'] = 'Allow anonymous only posting.';
+$string['anonymousonlydesc'] = 'If enabled, when anonymous posting is enabled for a forum, users can only post anonymously.';
 
 $string[''] = '';

--- a/layout.php
+++ b/layout.php
@@ -41,6 +41,7 @@ if (! $anonymousposting = get_config('local_anonymousposting', 'enabled')) {
 }
 
 $status = get_config('local_anonymousposting', 'forum_'.$id);
+$anonymousonly = get_config('local_anonymousposting', 'anonymousonly');
 
 $changeuserurl = $CFG->wwwroot.'/local/anonymousposting/changeuser.php?id='.$id;
 $strnewpost = get_string('newpost', 'local_anonymousposting');
@@ -50,6 +51,7 @@ $strenable = get_string('enable', 'local_anonymousposting');
 $strdisable = get_string('disable', 'local_anonymousposting');
 $strenabled = get_string('enabled', 'local_anonymousposting');
 $strdisabled = get_string('disabled', 'local_anonymousposting');
+$strforumreply = get_string('reply', 'mod_forum');
 
 $jsedit = "";
 if (has_capability('moodle/course:manageactivities', $context)) {
@@ -132,6 +134,19 @@ if ($status and !isset($SESSION->aucontext)) {
         }
     });
     ";
+
+    // If we only allow anonymous posting, then need to remove the post buttons.
+    if ($anonymousonly) {
+        $jsuser .= "
+            if (newpost) {
+                Y.one('#newdiscussionform input[type=\"submit\"]').remove();
+            }
+            replyposts.each(function (reply) {
+                var content = reply.getContent();
+                reply.setContent(content.replace('$strforumreply</a> |','</a>'));
+            });
+        ";
+    }
 
 }
 


### PR DESCRIPTION
We had a request from our faculty who wanted anonymous forums to have posting as anonymous be the only option. This is a patch to do that. Not sure if it would be useful to anyone else.